### PR TITLE
Fixes SRR (window is not defined)

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -255,7 +255,7 @@ export function getDaysDiff(date1, date2) {
 // ** Date Localization **
 
 export function registerLocale(localeName, localeData) {
-  const scope = window || global;
+  const scope = typeof window !== "undefined" ? window : global;
 
   if (!scope.__localeData__) {
     scope.__localeData__ = {};
@@ -264,13 +264,13 @@ export function registerLocale(localeName, localeData) {
 }
 
 export function setDefaultLocale(localeName) {
-  const scope = window || global;
+  const scope = typeof window !== "undefined" ? window : global;
 
   scope.__localeId__ = localeName;
 }
 
 export function getDefaultLocale() {
-  const scope = window || global;
+  const scope = typeof window !== "undefined" ? window : global;
 
   return scope.__localeId__;
 }
@@ -278,7 +278,7 @@ export function getDefaultLocale() {
 export function getLocaleObject(localeSpec) {
   if (typeof localeSpec === "string") {
     // Treat it as a locale name registered by registerLocale
-    const scope = window || global;
+    const scope = typeof window !== "undefined" ? window : global;
     return scope.__localeData__ ? scope.__localeData__[localeSpec] : null;
   } else {
     // Treat it as a raw date-fns locale object


### PR DESCRIPTION
Correctly validates if window object exists with ```typeof```